### PR TITLE
🔧 setup eleventy configuration files

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,0 +1,8 @@
+module.exports = function(eleventyConfig) {
+    // Directory changes
+    return {
+        dir: {
+            input: 'src'
+        }
+    }
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+_site

--- a/src/index.md
+++ b/src/index.md
@@ -1,0 +1,2 @@
+# Ben Kutil
+Test content generation from 11ty.

--- a/src/posts/2022-11-06-eleventy-setup.md
+++ b/src/posts/2022-11-06-eleventy-setup.md
@@ -1,0 +1,3 @@
+# November 6th, 2022
+- setup benkutil.com in cloudflare
+- setup `src` directory in github


### PR DESCRIPTION
Setup eleventy configuration file, and configure eleventy to look for content in `src` folder.

- :construction: add `src` folder - organize content and site related files into `src`
- :construction: add posts folders - add basic blog post folder to use
- :construction: add initial eleventy
- :wrench: update `.gitignore` with output - ignore output folder from eleventy.
