### PR TITLE
:sparkles: add list of past websites'

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -4,6 +4,7 @@ module.exports = function(eleventyConfig) {
         dir: {
             input: 'src',
             includes: '_includes',
+            data: '_data'
         }
     }
 };

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "command": "npm start",
+            "name": "Run npm start",
+            "request": "launch",
+            "type": "node-terminal"
+        },
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "npx @11ty/eleventy --serve"
   },
   "repository": {
     "type": "git",

--- a/src/_data/pastSites.json
+++ b/src/_data/pastSites.json
@@ -1,0 +1,10 @@
+[
+    {
+        "title": "2016",
+        "url": "https://2016.benkutil.com"
+    },
+    {
+        "title": "2020",
+        "url": "https://2020.benkutil.com"
+    }
+]

--- a/src/_includes/layouts/home.liquid
+++ b/src/_includes/layouts/home.liquid
@@ -5,7 +5,7 @@ templateClass: tmpl-home
 {{ content }}
 <h2>Past websites</h2>
 <ul>
-  {%- for item in pastSites -%}
+  {%- for item in pastSites reversed -%}
     <li>
       <a href="{{item.url}}" title="Open the {{item.title}} version of this website">{{item.title}}</a>
     </li>

--- a/src/_includes/layouts/home.liquid
+++ b/src/_includes/layouts/home.liquid
@@ -3,3 +3,9 @@ layout: layouts/base.liquid
 templateClass: tmpl-home
 ---
 {{ content }}
+<h2>Past years websites</h2>
+<ul>
+  {%- for item in pastSites -%}
+    {{item.title}}
+  {%- endfor -%}
+</ul>

--- a/src/_includes/layouts/home.liquid
+++ b/src/_includes/layouts/home.liquid
@@ -3,9 +3,11 @@ layout: layouts/base.liquid
 templateClass: tmpl-home
 ---
 {{ content }}
-<h2>Past years websites</h2>
+<h2>Past websites</h2>
 <ul>
   {%- for item in pastSites -%}
-    {{item.title}}
+    <li>
+      <a href="{{item.url}}" title="Open the {{item.title}} version of this website">{{item.title}}</a>
+    </li>
   {%- endfor -%}
 </ul>


### PR DESCRIPTION
Update site to show links to past websites
- add data folder and list of past websites
- update config with path to data folder
- add launch config for codespaces - runs `npm start` on launch run.
- add 11ty server config to package start command
- add template to display past websites
- update output of past sites - reverse list of past websites
