### PR TITLE
add canonical link tag #65

### DIFF
--- a/src/_data/siteData.json
+++ b/src/_data/siteData.json
@@ -1,4 +1,5 @@
 {
+    "url": "https://benkutil.com",
     "title": "Ben Kutil &ndash; Product and Growth Leader",
     "description": "I help organizations serve people better with technology."
 }

--- a/src/_includes/layouts/base.liquid
+++ b/src/_includes/layouts/base.liquid
@@ -11,6 +11,7 @@
     <meta name="description" content="{{ siteData.description | strip_html | strip_newlines | truncate: 160 }}">  
     {%- endif -%}
     
+    <link rel="canonical" href="{{ page.url | prepend: siteData.url  }}">
 
     <style type="text/css">
   	html { margin: 0; padding: 0; text-align: center; }


### PR DESCRIPTION
- add `url` to `siteData` - Adding a `url` node to `siteData` allows calling the url from everywhere within 11ty. - `siteData.url` currently points to `https://benkutil.com`. - in the future, it might be nice for this to configure automatically.
- add `canonical` link tag - uses `siteData.url` to get base URL. - uses `page.url` to get 11ty url for each page
