### PR TITLE
:sparkles: split RSS feeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "@11ty/eleventy": "^1.0.2"
   },
   "dependencies": {
-    "eleventy-xml-plugin": "^0.1.0"
+    "eleventy-xml-plugin": "github:sentience/eleventy-xml-plugin#dist"
   }
 }

--- a/src/_includes/layouts/base.liquid
+++ b/src/_includes/layouts/base.liquid
@@ -97,7 +97,10 @@
     </div>
     {{ content }}
     <footer>
-      <p>subscribe via <a href="{{ "/feed.xml" | prepend: siteData.url }}">RSS</a></p>
+      <p>Subscribe via RSS to <a href="{{ "/feed.xml" | prepend: siteData.url }}">all content</a>, 
+        <a href="{{ "feeds/posts.xml" | prepend: siteData.url }}">posts</a>, or
+        <a href="{{ "feeds/notes.xml" | prepend: siteData.url }}">notes</a>.
+      </p>
     </footer>
   </body>
 </html>

--- a/src/feed-notes.liquid
+++ b/src/feed-notes.liquid
@@ -12,10 +12,10 @@ eleventyExcludeFromCollections: true
     <pubDate>{{ page.date | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ page.date | date_to_rfc822 }}</lastBuildDate>
     <generator>Eleventy {{ eleventy.version }}</generator>
-    {%- for item in collections.notes -%}
+    {%- for item in collections.notes | reverse -%}
       <item>
         <title>{{ item.data.title | xml_escape }}</title>
-        <description>{{ item.content | xml_escape }}</description>
+        <description>{{ item.templateContent | xml_escape }}</description>
         <pubDate>{{ item.date | date_to_rfc822 }}</pubDate>
         <link>{{ item.url | prepend: siteData.url }}</link>
         <guid isPermaLink="true">{{ item.url | prepend: siteData.url  }}</guid>

--- a/src/feed-notes.liquid
+++ b/src/feed-notes.liquid
@@ -1,18 +1,18 @@
 ---
-permalink: feed.xml
+permalink: feeds/notes.xml
 eleventyExcludeFromCollections: true
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>{{ siteData.title | xml_escape }}</title>
-    <description>Posts and Notes from Ben Kutil</description>
+    <title>Notes from {{ siteData.title | xml_escape }}</title>
+    <description>Small thoughts from the day</description>
     <link>{{ siteData.url | append: '/' }}</link>
     <atom:link href="{{ "/feed.xml" | prepend: siteData.url }}" rel="self" type="application/rss+xml"/>
     <pubDate>{{ page.date | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ page.date | date_to_rfc822 }}</lastBuildDate>
     <generator>Eleventy {{ eleventy.version }}</generator>
-    {%- for item in collections.all -%}
+    {%- for item in collections.notes -%}
       <item>
         <title>{{ item.data.title | xml_escape }}</title>
         <description>{{ item.content | xml_escape }}</description>

--- a/src/feed-posts.liquid
+++ b/src/feed-posts.liquid
@@ -12,10 +12,10 @@ eleventyExcludeFromCollections: true
     <pubDate>{{ page.date | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ page.date | date_to_rfc822 }}</lastBuildDate>
     <generator>Eleventy {{ eleventy.version }}</generator>
-    {%- for item in collections.posts -%}
+    {%- for item in collections.posts | reverse -%}
       <item>
         <title>{{ item.data.title | xml_escape }}</title>
-        <description>{{ item.content | xml_escape }}</description>
+        <description>{{ item.data.content | xml_escape }}</description>
         <pubDate>{{ item.date | date_to_rfc822 }}</pubDate>
         <link>{{ item.url | prepend: siteData.url }}</link>
         <guid isPermaLink="true">{{ item.url | prepend: siteData.url  }}</guid>

--- a/src/feed-posts.liquid
+++ b/src/feed-posts.liquid
@@ -1,18 +1,18 @@
 ---
-permalink: feed.xml
+permalink: feeds/posts.xml
 eleventyExcludeFromCollections: true
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>{{ siteData.title | xml_escape }}</title>
-    <description>Posts and Notes from Ben Kutil</description>
+    <title>Posts from {{ siteData.title | xml_escape }}</title>
+    <description>Longer posts/thoughts on topics, mostly government and biking</description>
     <link>{{ siteData.url | append: '/' }}</link>
     <atom:link href="{{ "/feed.xml" | prepend: siteData.url }}" rel="self" type="application/rss+xml"/>
     <pubDate>{{ page.date | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ page.date | date_to_rfc822 }}</lastBuildDate>
     <generator>Eleventy {{ eleventy.version }}</generator>
-    {%- for item in collections.all -%}
+    {%- for item in collections.posts -%}
       <item>
         <title>{{ item.data.title | xml_escape }}</title>
         <description>{{ item.content | xml_escape }}</description>

--- a/src/feed.liquid
+++ b/src/feed.liquid
@@ -12,10 +12,10 @@ eleventyExcludeFromCollections: true
     <pubDate>{{ page.date | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ page.date | date_to_rfc822 }}</lastBuildDate>
     <generator>Eleventy {{ eleventy.version }}</generator>
-    {%- for item in collections.all -%}
+    {%- for item in collections.all | reverse -%}
       <item>
         <title>{{ item.data.title | xml_escape }}</title>
-        <description>{{ item.content | xml_escape }}</description>
+        <description>{{ item.templateContent | xml_escape }}</description>
         <pubDate>{{ item.date | date_to_rfc822 }}</pubDate>
         <link>{{ item.url | prepend: siteData.url }}</link>
         <guid isPermaLink="true">{{ item.url | prepend: siteData.url  }}</guid>

--- a/src/index.md
+++ b/src/index.md
@@ -2,6 +2,7 @@
 layout: layouts/home.liquid
 changeFreq: weekly
 priority: 1.0
+eleventyExcludeFromCollections: true
 ---
 I currently act as Senior Director for [Ad Hoc](https://adhoc.team)'s Solutions and Services. In my 6+ years at Ad Hoc, I've had the opportunity to define strategy, build services, lead teams, and coach people.
 


### PR DESCRIPTION
- create new xml feeds - split out Posts and Notes into different feeds - set main feed to include both posts and notes
- add links to each feed
- fix feed output - reverse output of collections, so that newest is first - output content in `<description>` field
- exclude homepage from collections
- update xml filter depedency - main repository didn’t accurately escape html entities, and owner wasn’t maintaining package
