### PR TITLE
update package url to use git+ssh

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "@11ty/eleventy": "^1.0.2"
   },
   "dependencies": {
-    "eleventy-xml-plugin": "^0.1.0"
+    "eleventy-xml-plugin": "https://github.com/sentience/eleventy-xml-plugin.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "@11ty/eleventy": "^1.0.2"
   },
   "dependencies": {
-    "eleventy-xml-plugin": "github:sentience/eleventy-xml-plugin#dist"
+    "eleventy-xml-plugin": "git+ssh://git@github.com/sentience/eleventy-xml-plugin#dist"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "@11ty/eleventy": "^1.0.2"
   },
   "dependencies": {
-    "eleventy-xml-plugin": "git+ssh://git@github.com/sentience/eleventy-xml-plugin#dist"
+    "eleventy-xml-plugin": "sentience/eleventy-xml-plugin#dist"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "@11ty/eleventy": "^1.0.2"
   },
   "dependencies": {
-    "eleventy-xml-plugin": "https://github.com/sentience/eleventy-xml-plugin.git"
+    "eleventy-xml-plugin": "https://github.com/sentience/eleventy-xml-plugin.git#dist"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "@11ty/eleventy": "^1.0.2"
   },
   "dependencies": {
-    "eleventy-xml-plugin": "sentience/eleventy-xml-plugin#dist"
+    "eleventy-xml-plugin": "^0.1.0"
   }
 }


### PR DESCRIPTION
Using GitHub shorthand for the [forked copy of eleventy-xml-plugin](https://github.com/sentience/eleventy-xml-plugin) caused Cloudflare Pages build step to fail.

Using the full https url and hash reference seems to work. It has slightly slower build times.