### PR TITLE
🐛 add safe to title output

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% if title %}{{title}} &ndash; {% endif %}{{ siteData.title }}</title>
+    <title>{% if title %}{{title | safe}} &ndash; {% endif %}{{ siteData.title | safe }}</title>
     {%- if description -%}
     <meta name="description" content="{{ description }}">
     {%- else -%}
@@ -12,7 +12,7 @@
     {%- endif -%}
     
     <link rel="canonical" href="{{ page.url | absoluteUrl(siteData.url) }}">
-    <link rel="alternate" type="application/rss+xml" title="{{ siteData.title }}" href="{{ '/feed.xml' | absoluteUrl(siteData.url) }}">
+    <link rel="alternate" type="application/rss+xml" title="{{ siteData.title | safe }}" href="{{ '/feed.xml' | absoluteUrl(siteData.url) }}">
     <style type="text/css">
   	html { margin: 0; padding: 0; text-align: center; }
   	body {

--- a/src/feed-notes.njk
+++ b/src/feed-notes.njk
@@ -5,7 +5,7 @@ eleventyExcludeFromCollections: true
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>Notes from {{ siteData.title }}</title>
+    <title>Notes from {{ siteData.title | safe }}</title>
     <description>Small thoughts from the day</description>
     <link>{{ siteData.url }}</link>
     <atom:link href="{{ permalink | absoluteUrl(siteData.url) }}" rel="self" type="application/rss+xml"/>

--- a/src/feed-posts.njk
+++ b/src/feed-posts.njk
@@ -5,7 +5,7 @@ eleventyExcludeFromCollections: true
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>Posts from {{ siteData.title }}</title>
+    <title>Posts from {{ siteData.title | safe }}</title>
     <description>Longer posts/thoughts on topics, mostly government and biking</description>
     <link>{{ siteData.url }}</link>
     <atom:link href="{{ permalink | absoluteUrl(siteData.url) }}" rel="self" type="application/rss+xml"/>

--- a/src/feed.njk
+++ b/src/feed.njk
@@ -5,7 +5,7 @@ eleventyExcludeFromCollections: true
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>{{ siteData.title }}</title>
+    <title>{{ siteData.title | safe }}</title>
     <description>Posts and Notes from Ben Kutil</description>
     <link>{{ siteData.url }}</link>
     <atom:link href="{{ permalink | absoluteUrl(siteData.url) }}" rel="self" type="application/rss+xml"/>


### PR DESCRIPTION
 - add `safe` filter to title output 
   - this allows &ndash; to render as &ndash;