### PR TITLE
setup webmentions

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,9 +1,14 @@
+const Webmentions = require("eleventy-plugin-webmentions");
 const pluginRss = require("@11ty/eleventy-plugin-rss");
 const htmlmin = require("html-minifier");
 
 module.exports = function(eleventyConfig) {
     // 11ty plugins
     eleventyConfig.addPlugin(pluginRss);
+    eleventyConfig.addPlugin(Webmentions, {
+        domain: "benkutil.com",
+        token: process.env.WEBMENTIONS_TOKEN,
+      });
     
     // run these configs in production only
     if (process.env.ELEVENTY_ENV === 'production' ) {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const Webmentions = require("eleventy-plugin-webmentions");
 const pluginRss = require("@11ty/eleventy-plugin-rss");
 const htmlmin = require("html-minifier");
@@ -7,7 +8,7 @@ module.exports = function(eleventyConfig) {
     eleventyConfig.addPlugin(pluginRss);
     eleventyConfig.addPlugin(Webmentions, {
         domain: "benkutil.com",
-        token: process.env.WEBMENTIONS_TOKEN,
+        token: process.env.WEBMENTIONS_TOKEN
       });
     
     // run these configs in production only

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+ELEVENTY_ENV=environment
+WEBMENTIONS_TOKEN=yourWebmentionTokenHere

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 node_modules
 package-lock.json
 _site

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 package-lock.json
 _site
+_webmentioncache

--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
   "devDependencies": {
     "@11ty/eleventy": "^2.0.0-beta.3",
     "@11ty/eleventy-plugin-rss": "^1.2.0",
+    "eleventy-plugin-webmentions": "^2.0.0",
     "html-minifier": "^4.0.0"
   },
   "dependencies": {
-    "@11ty/eleventy-upgrade-help": "^2.0.5"
+    "@11ty/eleventy-upgrade-help": "^2.0.5",
+    "dotenv": "^16.0.3"
   }
 }

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -13,6 +13,10 @@
     
     <link rel="canonical" href="{{ page.url | absoluteUrl(siteData.url) }}">
     <link rel="alternate" type="application/rss+xml" title="{{ siteData.title | safe }}" href="{{ '/feed.xml' | absoluteUrl(siteData.url) }}">
+    
+    <link rel="webmention" href="https://webmention.io/benkutil.com/webmention" />
+    <link rel="pingback" href="https://webmention.io/benkutil.com/xmlrpc" />
+
     <style type="text/css">
   	html { margin: 0; padding: 0; text-align: center; }
   	body {

--- a/src/_includes/layouts/content.njk
+++ b/src/_includes/layouts/content.njk
@@ -3,3 +3,4 @@ layout: layouts/base.njk
 templateClass: tmpl-content
 ---
 {{ content | safe }}
+{%- set currentPostMentions = webmentions | webmentionsForPage -%}


### PR DESCRIPTION
Add ability to display mentions from elsewhere on the web.

Uses the [11ty Webmentions Plugin](https://www.npmjs.com/package/eleventy-plugin-webmentions), and [Webmentions.io](https://webmentions.io).

I had a problem loading environment variables. Caused from not configuring/calling `dotenv` at the top of `eleventy.js`.

## References these websites:
- https://github.com/maxboeck/eleventy-webmentions
- https://sia.codes/posts/webmentions-eleventy-in-depth/
- https://github.com/11ty/eleventy/issues/782

## Commits
* add webmention and pingback links

* add sample environment

* ignore `.env` file

* add webmention and dotenv packages

* add webmentions plugin and configure

* add webmentions output to content page

* add dotenv

* ignore webmention cache